### PR TITLE
Fix TreeSet comparator in StopTimesByRouteAndHeadsign to correctly handle trips with no real-time arrival time

### DIFF
--- a/src/main/java/org/opentripplanner/index/model/StopTimesByRouteAndHeadsign.java
+++ b/src/main/java/org/opentripplanner/index/model/StopTimesByRouteAndHeadsign.java
@@ -29,7 +29,7 @@ public class StopTimesByRouteAndHeadsign {
     // Order times by actual arrival time, then by hashCode (just to prevent collisions if two
     // arrival/departures have the same time)
     private SortedSet<TripTimeShort> times = new TreeSet<>(Comparator.<TripTimeShort>comparingLong(
-            tt -> (tt.serviceDay+tt.realtimeArrival)).thenComparing(TripTimeShort::hashCode));
+            tt -> (tt.serviceDay + (tt.realtimeArrival == TripTimes.UNAVAILABLE ? tt.scheduledArrival : tt.realtimeArrival))).thenComparing(TripTimeShort::hashCode));
 
     private String headsign;
 


### PR DESCRIPTION
The sort key for trips with no real-time arrival was effectively their service day (minus one); this is of no consequence to API clients who re-sort arrivals correctly, but, more importantly, it leads `limitTimes()` to produce incorrect results (as `limitTimes()` assumes the trips are already in correctly-sorted order).

We observed anomalous behavior in the Nearby API where a stop which was served by a mix of trips originating from that stop (thus no real-time arrival time, as the ATS-A GTFS-rt feed only provides a departure time for origin terminals) and trips passing through the stop.  All of the originating trips sorted "before" the through trips, and then when `limitTimes` truncated the result to the first three arrivals (the default value for the Nearby API), it appeared as though the through trips were missing entirely.  Increasing the cutoff from three results to five or more revealed that the through trips were not missing, just incorrectly sorted.

Though it is probably of little consequence, it's also worth noting that the `TreeSet` comparator here uses arrival times for sorting, whereas `limitTimes` uses departure times when filtering out results which are beyond the specified time horizon.